### PR TITLE
allow installation on any prototype

### DIFF
--- a/pipe.js
+++ b/pipe.js
@@ -12,6 +12,6 @@ var pipe = module.exports = function pipe(s) {
   return s
 }
 
-pipe.install = function() {
-  pipe(require('stream').prototype)
+pipe.install = function(proto) {
+  pipe(proto || require('stream').prototype)
 }


### PR DESCRIPTION
Because there are classes that interface with streams but don't extend them :dancer: 