### PR TITLE
single line install for ES6 imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ a | b | c | process.stdout
 
 a.write('a-s-d-f') // OMG WTF? => F,D,S,A
 ```
+
+It is also possible to to install pipe directly by
+requiring the `register` module which can be handy with ES6:
+
+```js
+import 'pipe/register'
+
+// Instead of:
+import pipe from 'pipe'
+pipe.install()
+```

--- a/register.js
+++ b/register.js
@@ -1,0 +1,1 @@
+require('./').install();


### PR DESCRIPTION
ES6+ style registration by simply importing 'pipe/register'

For those using ES6+ syntax, it would be better to register pipe with:

```
import 'pipe/register';
```

instead of

```
require('pipe').install();
```
